### PR TITLE
Allow the 'list' command to proceed even when some adapters lack an address

### DIFF
--- a/prologix_netfinder/getifaddrs.py
+++ b/prologix_netfinder/getifaddrs.py
@@ -293,6 +293,10 @@ def getifaddrs() -> Generator[Tuple[AddressFamily, str, Dict[str, Any]], str, No
             name = ifa.ifa_name.decode("utf-8")
             flags = IFF(ifa.ifa_flags)
             if_info: Dict[str, Any] = {"flags": flags}
+            if ifa.ifa_addr is None:
+                # advance to the next interface
+                ifa = ifaddrs.from_address(ifa.ifa_next)
+                continue
             sa = sockaddr.from_address(ifa.ifa_addr)
             if sa.sa_family == AddressFamily.AF_INET:
                 if ifa.ifa_addr is not None:

--- a/prologix_netfinder/getifaddrs.py
+++ b/prologix_netfinder/getifaddrs.py
@@ -36,6 +36,7 @@ from ctypes import (
 )
 from collections import defaultdict
 from enum import IntFlag
+from logging import debug
 from socket import AddressFamily, inet_ntop  # pylint: disable=no-name-in-module
 from typing import Any, Dict, Generator, Tuple
 
@@ -294,6 +295,7 @@ def getifaddrs() -> Generator[Tuple[AddressFamily, str, Dict[str, Any]], str, No
             flags = IFF(ifa.ifa_flags)
             if_info: Dict[str, Any] = {"flags": flags}
             if ifa.ifa_addr is None:
+                debug("Skipping interface %s with no address" % name)
                 # advance to the next interface
                 ifa = ifaddrs.from_address(ifa.ifa_next)
                 continue


### PR DESCRIPTION
This PR makes the `list` command more robust when VPN adapters are present but unconfigured.

The `prologix-netfinder list` command was failing for me:

```
Traceback (most recent call last):
  File "/home/user/Downloads/prologix/.venv/bin/prologix-netfinder", line 8, in <module>
    sys.exit(main())
  File "/home/user/Downloads/prologix/prologix_netfinder/prologix_netfinder/nfcli.py", line 213, in main
    func(**kwargs)
  File "/home/user/Downloads/prologix/prologix_netfinder/prologix_netfinder/nfcli.py", line 39, in list_devices
    devices = find_all_devices(
  File "/home/user/Downloads/prologix/prologix_netfinder/prologix_netfinder/nfutil.py", line 820, in find_all_devices
    for name, addrs in getifinfo().items():
  File "/home/user/Downloads/prologix/prologix_netfinder/prologix_netfinder/getifaddrs.py", line 368, in getifinfo
    for fam, nam, dat in getifaddrs():
  File "/home/user/Downloads/prologix/prologix_netfinder/prologix_netfinder/getifaddrs.py", line 296, in getifaddrs
    sa = sockaddr.from_address(ifa.ifa_addr)
TypeError: integer expected
```

The culprit was a virtual VPN adapter that returned `None` for an address.  This PR allows `getifaddrs()` to skip adapters without an address while notifying the user (if DEBUG level logging is enabled.) 
